### PR TITLE
Add parsed json body to ES logs

### DIFF
--- a/researchapp/services/logging.py
+++ b/researchapp/services/logging.py
@@ -33,6 +33,7 @@ def _clean(loggable):
     Fields:
         - body
         - headers
+        - json
         - method
         - url
     """
@@ -43,5 +44,10 @@ def _clean(loggable):
 
     if hasattr(loggable, 'text'):
         data['body'] = loggable.text
+
+    try:
+        data['json'] = loggable.json()
+    except:  # pylint: disable=bare-except
+        pass
 
     return data


### PR DESCRIPTION
Kibana doesn't like objects nested in arrays. I updated the ES index for `response.json.entry`, but Kibana is still complaining. Despite that, based on this https://www.elastic.co/guide/en/elasticsearch/guide/current/nested-objects.html I should probably do that for the test suite logs when I update them too. Are we okay with losing all the data we have there currently?